### PR TITLE
Clean up deploy-gcp workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -45,7 +45,7 @@ jobs:
           cache: 'maven'
 
       - name: Build with Maven
-        run: mvn clean package
+        run: mvn -U -DskipTests=true clean package
         
       - name: Google Auth
         id: auth


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for deploying to GCP, focusing on improvements to the build process, file copying paths, and external URL generation. These changes streamline deployment and fix issues related to environment variables and build configuration.

**Build process improvements**
* The Maven build step now skips tests and forces dependency updates by using `mvn -U -DskipTests=true clean package`, which speeds up deployments and ensures dependencies are current.

**File path and environment variable fixes**
* The JAR file copy command now uses the correct relative path `./embabel-database-server/target/${{ env.JAR_NAME }}` to ensure the file is found and copied to the VM.
* The external URL generation step now references the correct VM instance input variable (`${{ github.event.inputs.vm_instance }}`) instead of the removed `APP_NAME` environment variable, avoiding misconfiguration.
* The unused `APP_NAME` environment variable has been removed from the workflow configuration to prevent confusion.