### PR TITLE
Add build failure and recovery notifications

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,3 +23,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -U -B test verify
+
+  # Build Failure Notification
+  notify:
+    needs: [build]
+    if: failure() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/discord-notify.yml@main
+    secrets: inherit
+
+  # Build Recovery ( on prior failure ) Notification
+  notify-recovery:
+    needs: [build]
+    if: success() && github.ref == 'refs/heads/main'
+    uses: embabel/embabel-build/.github/workflows/notify-recovery.yml@main
+    with:
+      branch: main
+    secrets: inherit


### PR DESCRIPTION
This pull request adds automated notifications for build failures and recoveries on the `main` branch to the GitHub Actions workflow. These notifications will help the team stay informed about the status of the CI pipeline.

**CI/CD workflow enhancements:**

* Added a `notify` job to trigger a Discord notification workflow when a build fails on the `main` branch.
* Added a `notify-recovery` job to trigger a recovery notification workflow when a previously failing build succeeds on the `main` branch.